### PR TITLE
fix community fund supporting material urls

### DIFF
--- a/community_fund/models.py
+++ b/community_fund/models.py
@@ -2,7 +2,6 @@ import uuid
 from os.path import basename
 from pathlib import Path
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models, transaction
 from django.template.loader import render_to_string
@@ -71,7 +70,6 @@ class CommunityActionFundApplication(models.Model):
             {
                 "application": self,
                 "form": CommunityActionFundApplicationForm(label_suffix=""),
-                "site_url": settings.SITE_URL.rstrip("/"),
             },
         )
 

--- a/community_fund/templates/community_fund/application.md
+++ b/community_fund/templates/community_fund/application.md
@@ -45,6 +45,6 @@
 {% if application.supporting_materials.exists %}
 ## Supporting Materials
 {% for material in application.supporting_materials.all %}
-- [{{ material.filename }}](<{{ site_url }}{{ material.file.url }}>)
+- [{{ material.filename }}](<{{ material.file.url }}>)
 {% endfor %}
 {% endif %}

--- a/pbaabp/settings.py
+++ b/pbaabp/settings.py
@@ -288,7 +288,12 @@ MEDIA_ROOT = BASE_DIR / "media"
 TESTING = "test" in sys.argv
 
 STORAGES = {
-    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "base_url": f"{SITE_URL.rstrip('/')}{MEDIA_URL}",
+        },
+    },
     "staticfiles": {
         # Use simpler storage during tests to avoid manifest requirement
         "BACKEND": (


### PR DESCRIPTION
## Describe your changes

Possible fix for the Community Fund supporting material url bug (urls malformed as `https://bikeaction.orghttps//prod.cdn.bikeaction.org/community-fund-supporting-materials/...`).

I wasn't able to reproduce this locally to confirm this fix, but it seems that `site_url` being prepended to `material.file.url` was causing the broken url. it looks like `site_url` resolves locally to `localhost:8000` but in prod is likely `bikeaction.org`, creating the malformed url. 

When i created a test application locally the supporting material url in the application page is `http://localhost:8000/media/community-fund-supporting-materials/test-title2-bike-bb828d15.jpg` and the link opened the file successfully. 

i'm having trouble confirming the fix locally and issues with the app crashing, so if someone is able to test this fix that would be awesome.

Screenshot showing the application on left and the opened supporting material file on the right:
<img width="1611" height="776" alt="image" src="https://github.com/user-attachments/assets/ceb0e44d-c41d-439a-a9b1-ae216f63fe94" />

## Issue ticket number and link
Issue #335 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Any other notes

